### PR TITLE
Fix Brill-Beggs Z-factor function name

### DIFF
--- a/modules/h2store/examples/exampleH2BrineSolubility.m
+++ b/modules/h2store/examples/exampleH2BrineSolubility.m
@@ -205,7 +205,7 @@ Temperature_K_ = tab_sol.("# temperature [°C]") + 273.15;  % Convert to Kelvin
 Pressure_Pa_ = tab_sol.("pressure [Pa]");
 
 % Calculate density of hydrogen using the Brill and Beggs correlation
-ZH2_corr = calculateBrillBreggsZfactorHydrogen(Temperature_K_, Pressure_Pa_);
+ZH2_corr = calculateBrillBeggsZfactorHydrogen(Temperature_K_, Pressure_Pa_);
 rhoH2_corr = Pressure_Pa_ .* mH2 ./ (ZH2_corr .* Joule .* Temperature_K_);
 
 % Calculate density of pure water using the Rowe-Chou correlation

--- a/modules/h2store/thermodynamics/calculateBrillBeggsZfactorHydrogen.m
+++ b/modules/h2store/thermodynamics/calculateBrillBeggsZfactorHydrogen.m
@@ -1,20 +1,22 @@
-function Z = calculateBrillBreggsZfactorHydrogen(T, P)
-% calculateBrillBeggsZfactorHydrogen  Computes the hydrogen density using the Brill and Beggs correlation.
+function Z = calculateBrillBeggsZfactorHydrogen(T, P)
+% calculateBrillBeggsZfactorHydrogen  Computes the gas compressibility factor
+%                                     for hydrogen using the Brill and Beggs
+%                                     correlation.
 %
 % SYNOPSIS:
-%   rho = calculateBrillBeggsZfactorHydrogen(T, P)
+%   Z = calculateBrillBeggsZfactorHydrogen(T, P)
 %
 % DESCRIPTION:
-%   This function calculates the hydrogen density based on the Brill and Beggs
-%   correlation, incorporating temperature (T) and pressure (P). The correlation
-%   is derived from empirical coefficients specific to hydrogen gas properties.
+%   This function returns the gas compressibility factor (\(Z\)) for hydrogen
+%   based on the Brill and Beggs correlation, incorporating temperature (\(T\))
+%   and pressure (\(P\)).
 %
 % INPUTS:
 %   T - Temperature in Kelvin (K)
-%   P - Pressure in megapascals (MPa)
+%   P - Pressure in Pascal (Pa)
 %
 % OUTPUTS:
-%   rho - Hydrogen density in kilograms per cubic meter (kg/m^3)
+%   Z - Gas compressibility factor [-]
 %
 % REFERENCE:
 %   Jafari Raad, Seyed Mostafa, Leonenko, Yuri, Hassanzadeh, Hassan, 2023.

--- a/modules/h2store/thermodynamics/generateH2BrineSolubilityTable.m
+++ b/modules/h2store/thermodynamics/generateH2BrineSolubilityTable.m
@@ -128,7 +128,7 @@ end
 mH2 = 2.016e-3;  % Molar mass of H2 (kg/mol)
 Joule = 8.314472;  % Ideal gas constant (J/(mol*K))
 T_K =temperatures'+273.15;
-ZH2 = calculateBrillBreggsZfactorHydrogen(T_K, pressures);
+ZH2 = calculateBrillBeggsZfactorHydrogen(T_K, pressures);
 rhoH2_corr = pressures .* mH2 ./ (ZH2 .* Joule .* T_K);
 % one can also extract NIST data
 % rhoH2_corr = getH2Densities(temperatures, pressures);

--- a/modules/h2store/thermodynamics/generateH2WaterSolubilityTable.m
+++ b/modules/h2store/thermodynamics/generateH2WaterSolubilityTable.m
@@ -132,7 +132,7 @@ mH2 = 2.016e-3;  % Molar mass of H2 (kg/mol)
 Joule = 8.314472;  % Ideal gas constant (J/(mol*K))
 
 T_K =temperatures'+273.15;
-ZH2 = calculateBrillBreggsZfactorHydrogen(T_K, pressures);
+ZH2 = calculateBrillBeggsZfactorHydrogen(T_K, pressures);
 rhoH2_corr = pressures .* mH2 ./ (ZH2 .* Joule .* T_K);
 % one can also extract NIST data
 % rhoH2_corr = getH2Densities(temperatures, pressures);


### PR DESCRIPTION
## Summary
- rename `calculateBrillBreggsZfactorHydrogen.m` -> `calculateBrillBeggsZfactorHydrogen.m`
- update calls in solubility generators and example script
- fix docstring to return Z-factor and correct units

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_687f7b517d9c832595e51cf4503a7178